### PR TITLE
Replace request method shorthand with .execute for proper RestClient option support

### DIFF
--- a/lib/keycloak-admin/client/configurable_token_client.rb
+++ b/lib/keycloak-admin/client/configurable_token_client.rb
@@ -16,13 +16,18 @@ module KeycloakAdmin
 
     def exchange_with(user_access_token, token_lifespan_in_seconds)
       response = execute_http do
-        RestClient.post(token_url, {
-          tokenLifespanInSeconds: token_lifespan_in_seconds
-        }.to_json, {
-          Authorization: "Bearer #{user_access_token}",
-          content_type:  :json,
-          accept:        :json
-        })
+        RestClient::Request.execute(
+          @configuration.options.merge(
+            method: :post,
+            url: token_url,
+            payload: { tokenLifespanInSeconds: token_lifespan_in_seconds }.to_json,
+            headers: {
+              Authorization: "Bearer #{user_access_token}",
+              content_type: :json,
+              accept: :json
+            }
+          )
+        )
       end
       TokenRepresentation.from_json(response.body)
     end

--- a/lib/keycloak-admin/client/user_client.rb
+++ b/lib/keycloak-admin/client/user_client.rb
@@ -84,7 +84,7 @@ module KeycloakAdmin
         RestClient::Request.execute(
           @configuration.rest_client_options.merge(
             method: :post,
-            url: imporsonation.impersonation_url,
+            url: impersonation.impersonation_url,
             payload: impersonation.body.to_json,
             headers: impersonation.headers
           )

--- a/lib/keycloak-admin/client/user_client.rb
+++ b/lib/keycloak-admin/client/user_client.rb
@@ -21,7 +21,14 @@ module KeycloakAdmin
     end
 
     def update(user_id, user_representation_body)
-      RestClient.put(users_url(user_id), user_representation_body.to_json, headers)
+      RestClient::Request.execute(
+        @configuration.rest_client_options.merge(
+          method: :put,
+          url: users_url(user_id),
+          payload: user_representation_body.to_json,
+          headers: headers
+        )
+      )
     end
 
     def get(user_id)
@@ -59,11 +66,14 @@ module KeycloakAdmin
 
     def update_password(user_id, new_password)
       execute_http do
-        RestClient.put(reset_password_url(user_id), {
-          type: "password",
-          value: new_password,
-          temporary: false
-        }.to_json, headers)
+        RestClient::Request.execute(
+          @configuration.rest_client_options.merge(
+            method: :put,
+            url: reset_password_url(user_id),
+            payload: { type: 'password', value: new_password, temporary: false }.to_json,
+            headers: headers
+          )
+        )
       end
       user_id
     end
@@ -71,7 +81,14 @@ module KeycloakAdmin
     def impersonate(user_id)
       impersonation = get_redirect_impersonation(user_id)
       response = execute_http do
-        RestClient.post(impersonation.impersonation_url, impersonation.body.to_json, impersonation.headers)
+        RestClient::Request.execute(
+          @configuration.rest_client_options.merge(
+            method: :post,
+            url: imporsonation.impersonation_url,
+            payload: impersonation.body.to_json,
+            headers: impersonation.headers
+          )
+        )
       end
       ImpersonationRepresentation.from_response(response, @configuration.server_domain)
     end
@@ -87,7 +104,14 @@ module KeycloakAdmin
       fed_id_rep.identity_provider = idp_id
 
       execute_http do
-        RestClient.post(federated_identity_url(user_id, idp_id), fed_id_rep.to_json, headers)
+        RestClient::Request.execute(
+          @configuration.rest_client_options.merge(
+            method: :post,
+            url: federated_identity_url(user_id, idp_id),
+            payload: fed_id_rep.to_json,
+            headers: headers
+          )
+        )
       end
     end
 


### PR DESCRIPTION
Prior to these changes, certain actions (primarily in `UserClient`) did not pass the global `RestClient` (as set with `KeycloakAdmin.configure`) option hash to `RestClient` as a result of their using `post` and `put` shorthand. This PR replaces shorthand request method calls with calls to the underlying `execute` method, thus allowing for advanced options to be passed.