### PR TITLE
JSONize empty payload in add_group

### DIFF
--- a/lib/keycloak-admin/client/user_client.rb
+++ b/lib/keycloak-admin/client/user_client.rb
@@ -36,7 +36,7 @@ module KeycloakAdmin
         @configuration.rest_client_options.merge(
           method: :put,
           url: "#{users_url(user_id)}/groups/#{group_id}",
-          payload: {},
+          payload: create_payload({}),
           headers: headers
         )
       )


### PR DESCRIPTION
Using a raw hash instead of JSON payload was causing a header override warning in rest-client.

See rest-client/rest-client#104 for details; because an empty hash is passed directly as the payload, rest-client complains about incompatible headers. Solution is to simply json encode the empty hash.