### PR TITLE
Feature: List user realm-level role mappings

### DIFF
--- a/lib/keycloak-admin/client/role_mapper_client.rb
+++ b/lib/keycloak-admin/client/role_mapper_client.rb
@@ -5,6 +5,13 @@ module KeycloakAdmin
       @user_resource = user_resource
     end
 
+    def list
+      response = execute_http do
+        RestClient::Resource.new(realm_level_url, @configuration.rest_client_options).get(headers)
+      end
+      JSON.parse(response).map { |role_as_hash| RoleRepresentation.from_hash(role_as_hash) }
+    end
+
     def save_realm_level(role_representation_list)
       execute_http do
         RestClient::Resource.new(realm_level_url, @configuration.rest_client_options).post(

--- a/spec/client/role_mapper_client_spec.rb
+++ b/spec/client/role_mapper_client_spec.rb
@@ -12,6 +12,27 @@ RSpec.describe KeycloakAdmin::RoleMapperClient do
     end
   end
 
+  describe "#list" do
+    let(:realm_name) { "valid-realm" }
+    let(:user_id)    { "test_user" }
+
+    before(:each) do
+      @role_mapper_client = KeycloakAdmin.realm(realm_name).user(user_id).role_mapper
+
+      stub_token_client
+      allow_any_instance_of(RestClient::Resource).to receive(:get)
+        .and_return '[{"id":"test_role_id","name":"test_role_name","composite": false}]'
+    end
+
+    it "list user realm-level role mappings" do
+      roles = @role_mapper_client.list
+      expect(roles.length).to eq 1
+      expect(roles[0].id).to eq "test_role_id"
+      expect(roles[0].name).to eq "test_role_name"
+      expect(roles[0].composite).to be false
+    end
+  end
+
   describe "#save_realm_level" do
     let(:realm_name) { "valid-realm" }
     let(:user_id)    { "test_user" }


### PR DESCRIPTION
Add feature to list user realm-level role mappings. From admin REST API [documentation](https://www.keycloak.org/docs-api/15.0/rest-api/index.html), if you ctrl+f `Get realm-level role mappings`. You will find the one with URL 

```
GET /{realm}/users/{id}/role-mappings/realm
```
which this new feature uses. I also added a simple unit test, like other similar methods.