### PR TITLE
Implements creating subgroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,16 @@ group_path = "/top"
 group_id = KeycloakAdmin.realm("a_realm").groups.create!(group_name, group_path)
 ```
 
+### Create a new subgroup of an existing group
+
+Create a new group as the child of an existing group.
+
+```ruby
+parent_id = "7686af34-204c-4515-8122-78d19febbf6e"
+group_name = "test"
+sub_group_id = KeycloakAdmin.realm("a_realm").groups.create_subgroup!(parent_id, group_name)
+```
+
 ### Get list of roles in a realm
 
 Returns an array of `KeycloakAdmin::RoleRepresentation`.

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -26,6 +26,16 @@ module KeycloakAdmin
       end
     end
 
+    def create_subgroup!(parent_id, name)
+      url = "#{groups_url(parent_id)}/children"
+      response = execute_http do
+        RestClient::Resource.new(url, @configuration.rest_client_options).post(
+          create_payload(build(name, nil)), headers
+        )
+      end
+      created_id(response)
+    end
+
     def groups_url(id=nil)
       if id
         "#{@realm_client.realm_admin_url}/groups/#{id}"

--- a/lib/keycloak-admin/representation/group_representation.rb
+++ b/lib/keycloak-admin/representation/group_representation.rb
@@ -2,13 +2,15 @@ module KeycloakAdmin
   class GroupRepresentation < Representation
     attr_accessor :id,
       :name,
-      :path
+      :path,
+      :sub_groups
 
     def self.from_hash(hash)
-      group      = new
-      group.id   = hash["id"]
-      group.name = hash["name"]
-      group.path = hash["path"]
+      group            = new
+      group.id         = hash["id"]
+      group.name       = hash["name"]
+      group.path       = hash["path"]
+      group.sub_groups = hash.fetch("subGroups", []).map { |sub_group_hash| self.from_hash(sub_group_hash) }
       group
     end
   end

--- a/spec/client/group_client_spec.rb
+++ b/spec/client/group_client_spec.rb
@@ -111,15 +111,26 @@ RSpec.describe KeycloakAdmin::GroupClient do
         'Create method returned status OK (Code: 200); expected status: Created (201)'
       )
     end
+  end
 
-    def stub_net_http_res(res_class, code, message)
-      net_http_res = double
-      allow(net_http_res).to receive(:message).and_return message
-      allow(net_http_res).to receive(:code).and_return code
-      allow(net_http_res).to receive(:is_a?) do |target_class|
-        target_class == res_class
-      end
-      allow(@response).to receive(:net_http_res).and_return net_http_res
+  describe "#create_subgroup!" do
+    let(:realm_name) { "valid-realm" }
+
+    before(:each) do
+      @group_client = KeycloakAdmin.realm(realm_name).groups
+
+      stub_token_client
+      @response = double headers: {
+        location: 'http://auth.service.io/auth/admin/realms/valid-realm/groups/7686af34-204c-4515-8122-78d19febbf6e'
+      }
+      allow_any_instance_of(RestClient::Resource).to receive(:post).and_return @response
+    end
+
+    it "creates a subgroup" do
+      stub_net_http_res(Net::HTTPCreated, 201, 'Created')
+
+      group_id = @group_client.create_subgroup!('be061c48-6edd-4783-a726-1a57d4bfa22b', 'subgroup-name')
+      expect(group_id).to eq '7686af34-204c-4515-8122-78d19febbf6e'
     end
   end
 end

--- a/spec/representation/group_representation_spec.rb
+++ b/spec/representation/group_representation_spec.rb
@@ -1,0 +1,15 @@
+
+RSpec.describe KeycloakAdmin::GroupRepresentation do
+  describe ".from_hash" do
+    it "parses the sub groups into group representations" do
+      group = described_class.from_hash({
+        "name" => "group a",
+        "subGroups" => [{
+          "name" => "subgroup b"
+        }]
+      })
+      expect(group.sub_groups.length).to eq 1
+      expect(group.sub_groups.first).to be_a described_class
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ def configure
     config.client_secret       = "aaaaaaaa"
     config.client_realm_name   = "master2"
     config.use_service_account = true
-  end 
+  end
 end
 
 RSpec.configure do |config|
@@ -26,4 +26,12 @@ def stub_token_client
     'test_access_token', 'token_type', 'expires_in', 'refresh_token',
     'refresh_expires_in', 'id_token', 'not_before_policy', 'session_state'
   )
+end
+
+def stub_net_http_res(res_class, code, message)
+  net_http_res = double(message:  message, code: code)
+  allow(net_http_res).to receive(:is_a?) do |target_class|
+    target_class == res_class
+  end
+  allow(@response).to receive(:net_http_res).and_return(net_http_res)
 end


### PR DESCRIPTION
With this change it is now possible to create child groups of an existing group.

```ruby
parent_id = "7686af34-204c-4515-8122-78d19febbf6e"
group_name = "test"
sub_group_id = KeycloakAdmin.realm("a_realm").groups.create_subgroup!(parent_id, group_name)
```

And while I was at it I also added the parsing of the `subGroups` field for the `GroupRepresentation`, which should implement #16.