### PR TITLE
Adds reader for resource id

### DIFF
--- a/lib/keycloak-admin/resource/base_role_containing_resource.rb
+++ b/lib/keycloak-admin/resource/base_role_containing_resource.rb
@@ -1,5 +1,7 @@
 module KeycloakAdmin
   class BaseRoleContainingResource
+    attr_reader :resource_id
+
     def initialize(configuration, realm_client, resource_id)
       @configuration = configuration
       raise ArgumentError.new("realm must be defined") unless realm_client.name_defined?


### PR DESCRIPTION
Adds an attribute reader for the `resource_id` on the base resource.