### PR TITLE
allow rest-client v2.0.2 dependency

### DIFF
--- a/keycloak-admin.gemspec
+++ b/keycloak-admin.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0")
   spec.require_paths = ["lib"]
-  
+
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency "http-cookie", "~> 1.0", ">= 1.0.3"
-  spec.add_dependency "rest-client", "~> 2.1"
+  spec.add_dependency "rest-client", "~> 2.0.2"
   spec.add_development_dependency "rspec",  "3.12.0"
   spec.add_development_dependency "byebug", "11.1.3"
 end

--- a/keycloak-admin.gemspec
+++ b/keycloak-admin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency "http-cookie", "~> 1.0", ">= 1.0.3"
-  spec.add_dependency "rest-client", "~> 2.0.2"
+  spec.add_dependency "rest-client", "~> 2.0"
   spec.add_development_dependency "rspec",  "3.12.0"
   spec.add_development_dependency "byebug", "11.1.3"
 end


### PR DESCRIPTION
This dependency is creating a dependency conflict with other gems. It doesn't look like downgrading this dependency causes any specs to fail. Would it be possible to make this more permissive?