### PR TITLE
Adapt example for setting RestClient options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All options have a default value. However, all of them can be changed in your in
 | `username` | `nil`| String | Optional | Username to access the Admin REST API. Recommended if `user_service_account` is set to `false`. | `mummy` |
 | `password` | `nil`| String | Optional | Clear password to access the Admin REST API. Recommended if `user_service_account` is set to `false`. | `bobby` |
 | `logger` | `Logger.new(STDOUT)`| Logger | Optional | The logger used by `keycloak-admin` | `Rails.logger` | 
-| `rest_client_options` | `{}`| Hash | Optional | Options to pass to `RestClient` | `{ verify_ssl: OpenSSL::SSL::VERIFY_NONE }` | 
+| `rest_client_options` | `{}`| Hash | Optional | Options to pass to `RestClient` | `{ timeout: 5 }` | 
 
 
 ## Use Cases

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ KeycloakAdmin.configure do |config|
   config.username            = ENV["KEYCLOAK_ADMIN_USER"]
   config.password            = ENV["KEYCLOAK_ADMIN_PASSWORD"]
   config.logger              = Rails.logger
-  config.rest_client_options = { verify_ssl: OpenSSL::SSL::VERIFY_NONE }
+
+  # You configure RestClient to your liking – see https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb for available options.
+  config.rest_client_options = { timeout: 5 }
 end
 ```
 This example is autoloaded in a Rails environment.

--- a/spec/client/client_client_spec.rb
+++ b/spec/client/client_client_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe KeycloakAdmin::ClientClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -123,7 +123,7 @@ RSpec.describe KeycloakAdmin::ClientClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
       expect(RestClient::Resource).to receive(:new).with(
         "http://auth.service.io/auth/admin/realms/valid-realm/clients/95b45037-3980-404c-ba12-784fa1baf2c2", rest_client_options).and_call_original

--- a/spec/client/client_role_mappings_client_spec.rb
+++ b/spec/client/client_role_mappings_client_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe KeycloakAdmin::ClientRoleMappingsClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -70,7 +70,7 @@ RSpec.describe KeycloakAdmin::ClientRoleMappingsClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/group_client_spec.rb
+++ b/spec/client/group_client_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe KeycloakAdmin::GroupClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -73,7 +73,7 @@ RSpec.describe KeycloakAdmin::GroupClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/identity_provider_client_spec.rb
+++ b/spec/client/identity_provider_client_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe KeycloakAdmin::IdentityProviderClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/realm_client_spec.rb
+++ b/spec/client/realm_client_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe KeycloakAdmin::RealmClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -87,7 +87,7 @@ RSpec.describe KeycloakAdmin::RealmClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -117,7 +117,7 @@ RSpec.describe KeycloakAdmin::RealmClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -143,7 +143,7 @@ RSpec.describe KeycloakAdmin::RealmClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/role_client_spec.rb
+++ b/spec/client/role_client_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe KeycloakAdmin::RoleClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -71,7 +71,7 @@ RSpec.describe KeycloakAdmin::RoleClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/role_mapper_client_spec.rb
+++ b/spec/client/role_mapper_client_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe KeycloakAdmin::RoleMapperClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/client/token_client_spec.rb
+++ b/spec/client/token_client_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
       stub_post
 

--- a/spec/client/user_client_spec.rb
+++ b/spec/client/user_client_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -167,7 +167,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -213,7 +213,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -246,7 +246,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(
@@ -273,7 +273,7 @@ RSpec.describe KeycloakAdmin::TokenClient do
     end
 
     it "passes rest client options" do
-      rest_client_options = {verify_ssl: OpenSSL::SSL::VERIFY_NONE}
+      rest_client_options = {timeout: 10}
       allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
 
       expect(RestClient::Resource).to receive(:new).with(

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe KeycloakAdmin::RealmClient do
   let(:use_service_account) { true }
   let(:username)            { "a" }
   let(:password)            { "b" }
-  let(:rest_client_options) { {verify_ssl: OpenSSL::SSL::VERIFY_NONE} }
+  let(:rest_client_options) { {timeout: 10 }
 
   before(:each) do
     @configuration                     = KeycloakAdmin::Configuration.new


### PR DESCRIPTION
`OpenSSL::SSL::VERIFY_NONE` is dangerous (see https://brakemanscanner.org/docs/warning_types/ssl_verification_bypass/). We don't want to even hint at its possible usage, so people (especially less experienced engineers) don't accidentally use it.