### PR TITLE
Add/List realm-role/s to a group, Allow role-names with spaces, List groups assigned to role

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keycloak-admin (1.1.0)
+    keycloak-admin (1.1.1)
       http-cookie (~> 1.0, >= 1.0.3)
       rest-client (~> 2.0)
 
@@ -10,14 +10,13 @@ GEM
   specs:
     byebug (11.1.3)
     diff-lcs (1.5.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    domain_name (0.6.20240107)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    mime-types (3.5.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
+    mime-types-data (3.2023.1205)
     netrc (0.11.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -37,9 +36,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ All options have a default value. However, all of them can be changed in your in
 * Get list of realms, save/update/delete a realm
 * Get list of client role mappings for a user/group
 * Get list of members of a group
+* Get list of groups that have a specific role assigned
+* Get list of realm-roles assigned to a group, add a realm-role to a group
 * Save client role mappings for a user/group
 * Save realm-level role mappings for a user/group
 * Add a Group on a User
@@ -365,6 +367,30 @@ You can specify paging with `first` and `max`:
 
 ```ruby
 KeycloakAdmin.realm("a_realm").group("group_id").members(first:0, max:100)
+```
+
+### Get list of groups that have a specific role assigned
+
+Returns an array of `KeycloakAdmin::GroupRepresentation`
+
+```ruby
+KeycloakAdmin.realm("a_realm").roles.list_groups("role_name")
+```
+
+### Get list of realm-roles assigned to a group
+
+Returns an array of `KeycloakAdmin::RoleRepresentation`
+
+```ruby
+KeycloakAdmin.realm("a_realm").groups.get_realm_level_roles("group_id")
+```
+
+### Add a realm-role to a group
+
+Returns added `KeycloakAdmin::RoleRepresentation`
+
+```ruby
+KeycloakAdmin.realm("a_realm").groups.add_realm_level_role_name!("group_id", "role_name")
 ```
 
 ### Get list of roles in a realm

--- a/lib/keycloak-admin/client/client.rb
+++ b/lib/keycloak-admin/client/client.rb
@@ -37,14 +37,6 @@ module KeycloakAdmin
       id
     end
 
-    def created_id_no_content(response)
-      unless response.net_http_res.is_a? Net::HTTPNoContent
-        raise "Create method returned status #{response.net_http_res.message} (Code: #{response.net_http_res.code}); expected status: No Content (204)"
-      end
-      (_head, _separator, id) = response.headers[:location].rpartition("/")
-      id
-    end
-
     def create_payload(value)
       if value.nil?
         ""

--- a/lib/keycloak-admin/client/client.rb
+++ b/lib/keycloak-admin/client/client.rb
@@ -37,6 +37,14 @@ module KeycloakAdmin
       id
     end
 
+    def created_id_no_content(response)
+      unless response.net_http_res.is_a? Net::HTTPNoContent
+        raise "Create method returned status #{response.net_http_res.message} (Code: #{response.net_http_res.code}); expected status: No Content (204)"
+      end
+      (_head, _separator, id) = response.headers[:location].rpartition("/")
+      id
+    end
+
     def create_payload(value)
       if value.nil?
         ""

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -77,8 +77,7 @@ module KeycloakAdmin
           create_payload([role_representation]), headers
         )
       end
-      # Keycloak returns 204 No Content on success
-      created_id_no_content(response)
+      role_representation
     end
 
     def groups_url(id=nil)

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -71,7 +71,13 @@ module KeycloakAdmin
 
     def add_realm_level_role_name!(group_id, role_name)
       role_representation = RoleClient.new(@configuration, @realm_client).get(role_name)
-      add_realm_level_role!(group_id, role_representation)
+      url = "#{groups_url(group_id)}/role-mappings/realm"
+      response = execute_http do
+        RestClient::Resource.new(url, @configuration.rest_client_options).post(
+          create_payload([role_representation]), headers
+        )
+      end
+      created_id(response)
     end
 
     def groups_url(id=nil)
@@ -83,16 +89,6 @@ module KeycloakAdmin
     end
 
     private
-
-    def add_realm_level_role!(group_id, role_representation)
-      url = "#{groups_url(group_id)}/role-mappings/realm"
-      response = execute_http do
-        RestClient::Resource.new(url, @configuration.rest_client_options).post(
-          create_payload([role_representation]), headers
-        )
-      end
-      created_id(response)
-    end
 
     def build(name, path)
       group      = GroupRepresentation.new

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -77,7 +77,8 @@ module KeycloakAdmin
           create_payload([role_representation]), headers
         )
       end
-      created_id(response)
+      # Keycloak returns 204 No Content on success
+      created_id_no_content(response)
     end
 
     def groups_url(id=nil)

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -61,6 +61,19 @@ module KeycloakAdmin
       JSON.parse(response).map { |user_as_hash| UserRepresentation.from_hash(user_as_hash) }
     end
 
+    def get_realm_level_roles(group_id)
+      url = "#{groups_url(group_id)}/role-mappings/realm"
+      response = execute_http do
+        RestClient::Resource.new(url, @configuration.rest_client_options).get(headers)
+      end
+      JSON.parse(response).map { |role_as_hash| RoleRepresentation.from_hash(role_as_hash) }
+    end
+
+    def add_realm_level_role_name!(group_id, role_name)
+      role_representation = RoleClient.new(@configuration, @realm_client).get(role_name)
+      add_realm_level_role!(group_id, role_representation)
+    end
+
     def groups_url(id=nil)
       if id
         "#{@realm_client.realm_admin_url}/groups/#{id}"
@@ -70,6 +83,16 @@ module KeycloakAdmin
     end
 
     private
+
+    def add_realm_level_role!(group_id, role_representation)
+      url = "#{groups_url(group_id)}/role-mappings/realm"
+      response = execute_http do
+        RestClient::Resource.new(url, @configuration.rest_client_options).post(
+          create_payload([role_representation]), headers
+        )
+      end
+      created_id(response)
+    end
 
     def build(name, path)
       group      = GroupRepresentation.new

--- a/lib/keycloak-admin/client/group_client.rb
+++ b/lib/keycloak-admin/client/group_client.rb
@@ -61,6 +61,7 @@ module KeycloakAdmin
       JSON.parse(response).map { |user_as_hash| UserRepresentation.from_hash(user_as_hash) }
     end
 
+    # Gets all realm-level roles for a group
     def get_realm_level_roles(group_id)
       url = "#{groups_url(group_id)}/role-mappings/realm"
       response = execute_http do
@@ -69,7 +70,9 @@ module KeycloakAdmin
       JSON.parse(response).map { |role_as_hash| RoleRepresentation.from_hash(role_as_hash) }
     end
 
+    # Adds a realm-level role to a group via the role name
     def add_realm_level_role_name!(group_id, role_name)
+      # creates a full role-representation object needed by the keycloak api to work
       role_representation = RoleClient.new(@configuration, @realm_client).get(role_name)
       url = "#{groups_url(group_id)}/role-mappings/realm"
       response = execute_http do

--- a/lib/keycloak-admin/client/role_client.rb
+++ b/lib/keycloak-admin/client/role_client.rb
@@ -13,7 +13,9 @@ module KeycloakAdmin
       JSON.parse(response).map { |role_as_hash| RoleRepresentation.from_hash(role_as_hash) }
     end
     
+    # Returns the role representation for the specified role name
     def get(name)
+      # allows special characters in the name like space
       name = URI.encode_uri_component(name)
       response = execute_http do
         RestClient::Resource.new(role_name_url(name), @configuration.rest_client_options).get(headers)
@@ -21,7 +23,9 @@ module KeycloakAdmin
       RoleRepresentation.from_hash JSON.parse(response)
     end
 
+    # Lists all groups that have the specified role name assigned
     def list_groups(name)
+      # allows special characters in the name like space
       name = URI.encode_uri_component(name)
       response = execute_http do
         RestClient::Resource.new("#{role_name_url(name)}/groups", @configuration.rest_client_options).get(headers)

--- a/lib/keycloak-admin/client/role_client.rb
+++ b/lib/keycloak-admin/client/role_client.rb
@@ -14,10 +14,19 @@ module KeycloakAdmin
     end
     
     def get(name)
+      name = URI.encode_uri_component(name)
       response = execute_http do
         RestClient::Resource.new(role_name_url(name), @configuration.rest_client_options).get(headers)
       end
       RoleRepresentation.from_hash JSON.parse(response)
+    end
+
+    def list_groups(name)
+      name = URI.encode_uri_component(name)
+      response = execute_http do
+        RestClient::Resource.new("#{role_name_url(name)}/groups", @configuration.rest_client_options).get(headers)
+      end
+      JSON.parse(response).map { |role_as_hash| GroupRepresentation.from_hash(role_as_hash) }
     end
 
     def save(role_representation)

--- a/lib/keycloak-admin/representation/role_representation.rb
+++ b/lib/keycloak-admin/representation/role_representation.rb
@@ -3,7 +3,8 @@ module KeycloakAdmin
     attr_accessor :id,
       :name,
       :composite,
-      :client_role
+      :client_role,
+      :container_id,
 
     def self.from_hash(hash)
       role             = new
@@ -11,6 +12,7 @@ module KeycloakAdmin
       role.name        = hash["name"]
       role.composite   = hash["composite"]
       role.client_role = hash["clientRole"]
+      role.container_id = hash["containerId"]
       role
     end
   end

--- a/lib/keycloak-admin/version.rb
+++ b/lib/keycloak-admin/version.rb
@@ -1,3 +1,3 @@
 module KeycloakAdmin
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
### Following features get added by this pull-request:
- List all realm-roles assigned to a group-id
- Add/Assign a realm-role to a group-id
- List all groups that have the given role-name assigned

### Following fixes get added by this pull-request:
- Allow the `role_name`-parameter to include special characters like spaces in following methods
  - .roles.get(role_name)
  - .roles.list_groups(role_name)