### PR TITLE
[Bug] The 'remove' operation of the 'RoleMapperClient' does not take the global rest options into account

### DIFF
--- a/lib/keycloak-admin/client/role_mapper_client.rb
+++ b/lib/keycloak-admin/client/role_mapper_client.rb
@@ -23,10 +23,12 @@ module KeycloakAdmin
     def remove_realm_level(role_representation_list)
       execute_http do
         RestClient::Request.execute(
-          method: :delete, 
-          url: realm_level_url, 
-          payload: create_payload(role_representation_list), 
-          headers: headers
+          @configuration.rest_client_options.merge(
+            method: :delete,
+            url: realm_level_url,
+            payload: create_payload(role_representation_list), 
+            headers: headers
+          )
         )
       end
     end

--- a/spec/client/client_authz_permission_client_spec.rb
+++ b/spec/client/client_authz_permission_client_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe KeycloakAdmin::ClientAuthzPermissionClient do
       it "does not raise any error" do
         expect {
           @realm.authz_permissions("", type)
-        }.to raise_error
+        }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/client/client_authz_policy_client_spec.rb
+++ b/spec/client/client_authz_policy_client_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe KeycloakAdmin::ClientAuthzPolicyClient do
       it "does not raise any error" do
         expect {
           @realm.authz_policies("", type)
-        }.to raise_error
+        }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/client/role_mapper_client_spec.rb
+++ b/spec/client/role_mapper_client_spec.rb
@@ -65,4 +65,49 @@ RSpec.describe KeycloakAdmin::RoleMapperClient do
       @role_mapper_client.save_realm_level(role_list)
     end
   end
+
+  describe "#remove_realm_level" do
+    let(:realm_name) { "valid-realm" }
+    let(:user_id)    { "test_user" }
+    let(:role_list) { [
+      KeycloakAdmin::RoleRepresentation.from_hash(
+        "id" => "d9e3376b-f602-4086-8eee-89fea73c73ea"
+      )
+    ] }
+    let(:expected_url) { "http://auth.service.io/auth/admin/realms/valid-realm/users/test_user/role-mappings/realm" }
+
+    before(:each) do
+      @role_mapper_client = KeycloakAdmin.realm(realm_name).user(user_id).role_mapper
+
+      stub_token_client
+    end
+
+    it "removes realm-level role mappings" do
+      expect(RestClient::Request).to receive(:execute).with(
+        hash_including(
+          method: :delete,
+          url: expected_url,
+          payload: role_list.to_json
+        )
+      )
+
+      @role_mapper_client.remove_realm_level(role_list)
+    end
+
+    it "passes rest client options" do
+      rest_client_options = {timeout: 10}
+      allow_any_instance_of(KeycloakAdmin::Configuration).to receive(:rest_client_options).and_return rest_client_options
+      
+      expect(RestClient::Request).to receive(:execute).with(
+        hash_including(
+          method: :delete,
+          url: expected_url,
+          payload: role_list.to_json,
+          timeout: 10
+        )
+      )
+
+      @role_mapper_client.remove_realm_level(role_list)
+    end
+  end
 end

--- a/spec/integration/client_authorization_spec.rb
+++ b/spec/integration/client_authorization_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'ClientAuthorization' do
 
-  before do
-    skip unless ENV["GITHUB_ACTIONS"]
+  before(:each) do
+    skip("This test requires to be run in a Github action.")  unless ENV["GITHUB_ACTIONS"]
 
     KeycloakAdmin.configure do |config|
       config.use_service_account = false
@@ -14,14 +14,12 @@ RSpec.describe 'ClientAuthorization' do
     end
   end
 
-  after do
+  after(:each) do
     configure
   end
 
   describe "ClientAuthorization Suite" do
     it do
-      skip unless ENV["GITHUB_ACTIONS"]
-
       realm_name = "dummy"
 
       client = KeycloakAdmin.realm(realm_name).clients.find_by_client_id("dummy-client")


### PR DESCRIPTION
This pull request fixes https://github.com/looorent/keycloak-admin-ruby/issues/37 

